### PR TITLE
fix(auth): fix login, request now uses unauthenticated

### DIFF
--- a/src/app/modular/auth/actions.ts
+++ b/src/app/modular/auth/actions.ts
@@ -22,7 +22,8 @@ export const login = (
 ): ThunkAction<void, RootState, unknown, Action> => (async (dispatch) => {
   dispatch(loginStart());
   try {
-    const { token, user }: any = await request.post({
+    const { token, user }: any = await request.unauthenticatedRequest({
+      method: 'POST',
       url: 'login',
       body: { email, password },
     });


### PR DESCRIPTION
Previously login used the `request.post` method which generates its headers automatically with a `Bearer` token. When unauthenticated, this causes an error in some browsers with certain extensions.

fixes #18 (maybe)