### PR TITLE
Auth loading modal

### DIFF
--- a/src/components/Modals/AuthLoadingModal/index.tsx
+++ b/src/components/Modals/AuthLoadingModal/index.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
   },
   loading: {
     marginTop: theme.spacing(1),
-  }
+  },
 }));
 
 const AuthLoadingModal: React.FC<Props> = ({

--- a/src/components/Modals/AuthLoadingModal/index.tsx
+++ b/src/components/Modals/AuthLoadingModal/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography } from '@material-ui/core';
+import { Typography, LinearProgress } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 import { connect } from 'react-redux';
 import Container from '../container';
@@ -13,17 +14,35 @@ interface ConnectedProps {
 
 type Props = ConnectedProps;
 
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    outline: 'none',
+  },
+  linearProgress: {
+    width: '100%',
+    marginTop: theme.spacing(1),
+  },
+  loading: {
+    marginTop: theme.spacing(1),
+  }
+}));
+
 const AuthLoadingModal: React.FC<Props> = ({
   loading,
-}: Props) => (
-  <Container
-    open={loading}
-  >
-    <Typography>
-      Loading!
-    </Typography>
-  </Container>
-);
+}: Props) => {
+  const classes = useStyles();
+  return (
+    <Container
+      open={loading}
+      className={classes.paper}
+    >
+      <LinearProgress className={classes.linearProgress} color="secondary" />
+      <Typography className={classes.loading}>
+        Loading...
+      </Typography>
+    </Container>
+  );
+};
 
 const mapStateToProps = (state: RootState): Props => ({
   loading: authDuck.selectors.loading(state),


### PR DESCRIPTION
- Added a linear progress bar

<img width="479" alt="Screen Shot 2020-08-08 at 12 48 30 AM" src="https://user-images.githubusercontent.com/32988302/89702648-662b3300-d911-11ea-95ca-754e6439ab57.png">
<img width="415" alt="Screen Shot 2020-08-08 at 12 47 48 AM" src="https://user-images.githubusercontent.com/32988302/89702649-688d8d00-d911-11ea-8644-d8c28ef02649.png">

